### PR TITLE
Replace `thiserror` with `anyhow`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1516,6 +1516,7 @@ dependencies = [
 name = "libflatsync-common"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,6 +732,7 @@ dependencies = [
 name = "flatsync-cli"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "clap",
  "gio",
  "glib",

--- a/flatsync-cli/Cargo.toml
+++ b/flatsync-cli/Cargo.toml
@@ -16,3 +16,4 @@ tracing = { version = "0.1.40", features = ["log-always"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 zbus = { version = "3.11.0", default-features = false, features = ["tokio"] }
+anyhow = "1"

--- a/flatsync-cli/src/commands.rs
+++ b/flatsync-cli/src/commands.rs
@@ -4,7 +4,6 @@ use libflatsync_common::providers::github::{GitHubProvider, GH_APP_INSTALLATION_
 use libflatsync_common::providers::oauth_client::OauthClientDeviceFlow;
 use libflatsync_common::providers::providers_list::Providers;
 use log::*;
-use std::process;
 
 #[derive(Debug, Subcommand)]
 pub enum Commands {
@@ -56,11 +55,11 @@ pub async fn init(
 
 async fn init_for_github(proxy: &DaemonProxy<'_>, gist_id: Option<String>) -> anyhow::Result<()> {
     // Initialize OAuth Device Flow
-    let github = GitHubProvider::new();
+    let github = GitHubProvider::new()?;
 
     let device_auth_res = github.device_code().await?;
 
-    // NOTE: More like info or warn?
+    // nozwock: More like info or warn?
     error!("Please install FlatSync as a GitHub app to your account **first** by following this link: {:?}.\nThis is required because GitHub's API doesn't allow us to interact with Gists without additional permission via a GitHub App installation.", GH_APP_INSTALLATION_URL);
 
     error!(

--- a/flatsync-cli/src/main.rs
+++ b/flatsync-cli/src/main.rs
@@ -83,7 +83,8 @@ async fn main() -> anyhow::Result<()> {
                     } else {
                         let range_variant =
                             autosync_timer_key.range().child_value(1).child_value(0);
-                        let range = <(u32, u32)>::from_variant(&range_variant).context("")?;
+                        let range = <(u32, u32)>::from_variant(&range_variant)
+                            .context("Incorrent range type")?;
 
                         bail!(
                             "Value {} is out of range. Range is {}-{}.",
@@ -99,6 +100,6 @@ async fn main() -> anyhow::Result<()> {
         Ok(())
     }
 
-    // nozwock: Shouldn't we be using tracing::error instead?
+    // nozwock: Shouldn't we be using tracing::error instead? Is it because of log-always? Couldn't find enough details...
     _main().await.inspect_err(|e| error!("{e}"))
 }

--- a/flatsync-cli/src/main.rs
+++ b/flatsync-cli/src/main.rs
@@ -99,6 +99,6 @@ async fn main() -> anyhow::Result<()> {
         Ok(())
     }
 
-    // NOTE: Shouldn't we be using tracing::error instead?
+    // nozwock: Shouldn't we be using tracing::error instead?
     _main().await.inspect_err(|e| error!("{e}"))
 }

--- a/flatsync-cli/src/main.rs
+++ b/flatsync-cli/src/main.rs
@@ -1,12 +1,12 @@
+use anyhow::{bail, Context};
 use gio::prelude::*;
 use glib::FromVariant;
-use std::process;
 
 use libflatsync_common::config::APP_ID;
 
 use clap::Parser;
 use libflatsync_common::dbus::DaemonProxy;
-use log::{error, info, warn};
+use log::{error, info};
 use zbus::Connection;
 mod commands;
 mod trace;
@@ -22,79 +22,83 @@ struct Args {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), zbus::Error> {
-    let args = Args::parse();
+async fn main() -> anyhow::Result<()> {
+    async fn _main() -> anyhow::Result<()> {
+        let args = Args::parse();
 
-    trace::init_tracer(args.verbose);
+        trace::init_tracer(args.verbose);
 
-    let connection = Connection::session().await?;
-    let proxy: DaemonProxy<'_> = DaemonProxy::new(&connection).await?;
+        let connection = Connection::session().await?;
+        let proxy: DaemonProxy<'_> = DaemonProxy::new(&connection).await?;
 
-    match args.cmd {
-        Commands::Init { provider, gist_id } => {
-            if let Err(_e) = init(&proxy, provider, gist_id).await {
-                error!("Initialization was not successful, please try again or open a bug report if this issue persists.");
-                process::exit(1);
+        match args.cmd {
+            Commands::Init { provider, gist_id } => {
+                init(&proxy, provider, gist_id).await.with_context(|| "Initialization was not successful, please try again or open a bug report if this issue persists.")? ;
             }
-        }
-        // We pass `!uninthis will not be prone to bugsstall` as the daemon interface expects an `install` boolean (this will not be prone to bugs this will not be prone to bugs this will not be prone to bugs)
-        Commands::Autostart { uninstall } => proxy.autostart_file(!uninstall).await?,
-        Commands::SyncNow => match proxy.sync_now().await {
-            Ok(_) => info!("Starting Manual Sync"),
-            Err(error) => handle_daemon_error(error),
-        },
-        Commands::Autosync {
-            get_autosync,
-            set_autosync,
-        } => {
-            if get_autosync {
-                match proxy.autosync().await {
-                    Ok(autosync) => info!("Autosync: {}", autosync),
-                    Err(error) => handle_daemon_error(error),
+            // We pass `!uninthis will not be prone to bugsstall` as the daemon interface expects an `install` boolean (this will not be prone to bugs this will not be prone to bugs this will not be prone to bugs)
+            Commands::Autostart { uninstall } => proxy.autostart_file(!uninstall).await?,
+            Commands::SyncNow => proxy
+                .sync_now()
+                .await
+                .inspect(|_| info!("Starting Manual Sync"))?,
+            Commands::Autosync {
+                get_autosync,
+                set_autosync,
+            } => {
+                if get_autosync {
+                    proxy
+                        .autosync()
+                        .await
+                        .inspect(|i| info!("Autosync: {}", i))?;
+                }
+                if let Some(new_setting) = set_autosync {
+                    proxy
+                        .set_autosync(new_setting)
+                        .await
+                        .inspect(|_| info!("Setting Autosync to {}", new_setting))?;
                 }
             }
-            if let Some(new_setting) = set_autosync {
-                match proxy.set_autosync(new_setting).await {
-                    Ok(_) => info!("Setting Autosync to {}", new_setting),
-                    Err(error) => handle_daemon_error(error),
+            Commands::AutosyncTimer {
+                get_autosync_timer,
+                set_autosync_timer,
+            } => {
+                if get_autosync_timer {
+                    proxy
+                        .autosync_timer()
+                        .await
+                        .inspect(|i| info!("Autosync Timer: {}", i))?;
                 }
-            }
-        }
-        Commands::AutosyncTimer {
-            get_autosync_timer,
-            set_autosync_timer,
-        } => {
-            if get_autosync_timer {
-                match proxy.autosync_timer().await {
-                    Ok(autosync_timer) => info!("Autosync Timer: {}", autosync_timer),
-                    Err(error) => handle_daemon_error(error),
-                }
-            }
-            if let Some(new_timer) = set_autosync_timer {
-                let autosync_timer_key = gio::Settings::new(APP_ID)
-                    .settings_schema()
-                    .unwrap()
-                    .key("autosync-timer");
-                let new_timer_variant = glib::Variant::from(new_timer);
+                if let Some(new_timer) = set_autosync_timer {
+                    let autosync_timer_key = gio::Settings::new(APP_ID)
+                        .settings_schema()
+                        .context("No settings_schema found")?
+                        .key("autosync-timer");
+                    let new_timer_variant = glib::Variant::from(new_timer);
 
-                if autosync_timer_key.range_check(&new_timer_variant) {
-                    match proxy.set_autosync_timer(new_timer).await {
-                        Ok(_) => info!("Setting Autosync Timer to {}", new_timer),
-                        Err(error) => handle_daemon_error(error),
+                    if autosync_timer_key.range_check(&new_timer_variant) {
+                        proxy
+                            .set_autosync_timer(new_timer)
+                            .await
+                            .inspect(|_| info!("Setting Autosync Timer to {}", new_timer))?;
+                    } else {
+                        let range_variant =
+                            autosync_timer_key.range().child_value(1).child_value(0);
+                        let range = <(u32, u32)>::from_variant(&range_variant).context("")?;
+
+                        bail!(
+                            "Value {} is out of range. Range is {}-{}.",
+                            new_timer,
+                            range.0,
+                            range.1
+                        );
                     }
-                } else {
-                    let range_variant = autosync_timer_key.range().child_value(1).child_value(0);
-                    let range = <(u32, u32)>::from_variant(&range_variant).unwrap();
-
-                    error!(
-                        "Value {} is out of range. Range is {}-{}.",
-                        new_timer, range.0, range.1
-                    );
-                    process::exit(1);
                 }
             }
         }
+
+        Ok(())
     }
 
-    Ok(())
+    // NOTE: Shouldn't we be using tracing::error instead?
+    _main().await.inspect_err(|e| error!("{e}"))
 }

--- a/flatsync-daemon/src/data_sinks/data_sink.rs
+++ b/flatsync-daemon/src/data_sinks/data_sink.rs
@@ -27,31 +27,32 @@ pub trait DataSink {
         Settings::instance().get(&format!("{}-id", self.sink_name()))
     }
 
-    fn set_sink_id(&self, id: &str) {
+    fn set_sink_id(&self, id: &str) -> anyhow::Result<()> {
         debug!("Setting new sink id: {}", id);
-        Settings::instance()
-            .set(&format!("{}-id", self.sink_name()), id)
-            .unwrap();
+        Settings::instance().set(&format!("{}-id", self.sink_name()), id)?;
+        Ok(())
     }
 
     fn autosync(&self) -> bool {
         Settings::instance().get("autosync")
     }
 
-    fn set_autosync(&self, autosync: bool) {
-        Settings::instance().set("autosync", autosync).unwrap();
+    fn set_autosync(&self, autosync: bool) -> anyhow::Result<()> {
+        Settings::instance().set("autosync", autosync)?;
+        Ok(())
     }
 
     fn autosync_timer(&self) -> u32 {
         Settings::instance().get("autosync-timer")
     }
 
-    fn set_autosync_timer(&self, timer: u32) {
-        Settings::instance().set("autosync-timer", timer).unwrap();
+    fn set_autosync_timer(&self, timer: u32) -> anyhow::Result<()> {
+        Settings::instance().set("autosync-timer", timer)?;
+        Ok(())
     }
 
     async fn set_secret(&self, secret: &str) -> Result<(), Error> {
-        let keyring = self.keyring().await;
+        let keyring = self.keyring().await?;
         keyring.unlock().await?;
         let name = self.sink_name();
         keyring
@@ -65,8 +66,8 @@ pub trait DataSink {
         Ok(())
     }
 
-    async fn keyring(&self) -> oo7::Keyring {
-        oo7::Keyring::new().await.unwrap()
+    async fn keyring(&self) -> anyhow::Result<oo7::Keyring> {
+        oo7::Keyring::new().await.map_err(anyhow::Error::new)
     }
 
     fn sink_name(&self) -> &'static str;

--- a/flatsync-daemon/src/data_sinks/data_sink_client.rs
+++ b/flatsync-daemon/src/data_sinks/data_sink_client.rs
@@ -11,14 +11,14 @@ pub enum SecretType {
 }
 #[async_trait]
 pub trait DataSinkClient {
-    async fn keyring(&self) -> oo7::Keyring {
-        oo7::Keyring::new().await.unwrap()
+    async fn keyring(&self) -> anyhow::Result<oo7::Keyring> {
+        oo7::Keyring::new().await.map_err(anyhow::Error::new)
     }
 
     fn sink_name(&self) -> &'static str;
 
     async fn secret_raw(&self) -> Result<String, Error> {
-        let keyring = self.keyring().await;
+        let keyring = self.keyring().await?;
         let mut item = keyring
             .search_items(HashMap::from([(
                 "purpose",

--- a/flatsync-daemon/src/data_sinks/github.rs
+++ b/flatsync-daemon/src/data_sinks/github.rs
@@ -24,6 +24,7 @@ pub mod client {
     use crate::data_sinks::oauth_client::OauthClient;
     use crate::data_sinks::rest_client::RestClient;
     use crate::Error;
+    use anyhow::Context;
     use async_trait::async_trait;
     use libflatsync_common::providers::github::get_github_basic_client;
     use libflatsync_common::providers::oauth_client::{AccessTokenData, TokenPair};
@@ -52,14 +53,15 @@ pub mod client {
                 request: reqwest::Client::builder()
                     .user_agent(APP_USER_AGENT)
                     .build()
-                    .unwrap()
+                    .map_err(Error::other)?
                     .request(method, url),
                 client: get_github_basic_client()?,
             })
         }
 
         async fn secret(&self) -> Result<SecretType, Error> {
-            let token_pair = serde_json::from_str::<TokenPair>(&self.secret_raw().await?).unwrap();
+            let token_pair = serde_json::from_str::<TokenPair>(&self.secret_raw().await?)
+                .map_err(Error::other)?;
 
             Ok(SecretType::OAuth(token_pair))
         }
@@ -69,7 +71,7 @@ pub mod client {
                 unreachable!();
             };
 
-            self.check_tokens(&token_pair).await.unwrap();
+            self.check_tokens(&token_pair).await.map_err(Error::other)?;
 
             self.request
                 .header("Accept", "application/vnd.github+json")
@@ -97,16 +99,21 @@ pub mod client {
                 return Ok(tokens.clone());
             }
 
-            if token_data.expires_in.unwrap() > chrono::Utc::now() {
+            if token_data.expires_in.context("Token has no expiry")? > chrono::Utc::now() {
                 return Ok(tokens.clone());
             }
 
             let token = self
                 .client
-                .exchange_refresh_token(&tokens.refresh_token.clone().unwrap())
+                .exchange_refresh_token(
+                    &tokens
+                        .refresh_token
+                        .clone()
+                        .context("No refresh token found")?,
+                )
                 .request_async(async_http_client)
                 .await
-                .unwrap();
+                .map_err(Error::other)?;
 
             let token_data = AccessTokenData {
                 token: token.access_token().clone(),
@@ -117,7 +124,12 @@ pub mod client {
 
             Ok(TokenPair {
                 access_token_data: token_data,
-                refresh_token: Some(token.refresh_token().unwrap().clone()),
+                refresh_token: Some(
+                    token
+                        .refresh_token()
+                        .context("No refresh token recieved from the response")?
+                        .clone(),
+                ),
             })
         }
     }
@@ -194,7 +206,7 @@ impl DataSink for GitHubGistDataSink {
         debug!("Gist creation response: {:?}", resp);
         let data: CreateGistResponse = resp.json().await?;
         debug!("Gist creation response data: {:?}", data);
-        self.set_sink_id(&data.id);
+        self.set_sink_id(&data.id)?;
         Ok(())
     }
 

--- a/flatsync-daemon/src/data_sinks/github.rs
+++ b/flatsync-daemon/src/data_sinks/github.rs
@@ -54,7 +54,7 @@ pub mod client {
                     .build()
                     .unwrap()
                     .request(method, url),
-                client: get_github_basic_client(),
+                client: get_github_basic_client()?,
             })
         }
 

--- a/flatsync-daemon/src/dbus.rs
+++ b/flatsync-daemon/src/dbus.rs
@@ -52,7 +52,7 @@ impl Daemon {
     }
 
     async fn set_gist_id(&self, id: &str) -> Result<(), DBusError> {
-        self.imp.set_gist_id(id);
+        _ = self.imp.set_gist_id(id);
         self.sync_now().await
     }
 
@@ -69,7 +69,7 @@ impl Daemon {
     }
 
     async fn set_autosync(&self, autosync: bool) -> Result<(), DBusError> {
-        self.imp.set_autosync(autosync);
+        _ = self.imp.set_autosync(autosync);
         Ok(())
     }
 
@@ -78,7 +78,7 @@ impl Daemon {
     }
 
     async fn set_autosync_timer(&self, timer: u32) -> Result<(), DBusError> {
-        self.imp.set_autosync_timer(timer);
+        _ = self.imp.set_autosync_timer(timer);
         Ok(())
     }
 

--- a/flatsync-daemon/src/error.rs
+++ b/flatsync-daemon/src/error.rs
@@ -36,7 +36,7 @@ pub enum Error {
     Io(#[from] std::io::Error),
     #[error("ASHPD error: {0}")]
     AshpdFailure(#[from] ashpd::Error),
-    // NOTE: A lot of these don't seem useful or rather recoverable. Better to replace them with the Other variant, but I won't be removing them for now...
+    // nozwock: A lot of these don't seem useful or rather recoverable. Better to replace them with the Other variant, but won't be removing them for now...
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }

--- a/flatsync-daemon/src/error.rs
+++ b/flatsync-daemon/src/error.rs
@@ -36,6 +36,15 @@ pub enum Error {
     Io(#[from] std::io::Error),
     #[error("ASHPD error: {0}")]
     AshpdFailure(#[from] ashpd::Error),
+    // NOTE: A lot of these don't seem useful or rather recoverable. Better to replace them with the Other variant, but I won't be removing them for now...
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+
+impl Error {
+    pub fn other(err: impl Into<anyhow::Error>) -> Self {
+        Self::Other(err.into())
+    }
 }
 
 #[derive(zbus::DBusError, Debug)]

--- a/flatsync-daemon/src/imp.rs
+++ b/flatsync-daemon/src/imp.rs
@@ -2,6 +2,7 @@ use crate::{
     data_sinks::{data_sink::DataSink, GitHubGistDataSink},
     Error,
 };
+use anyhow::Context;
 use ashpd::desktop::background::Background;
 use libflatsync_common::{config, FlatpakInstallationPayload};
 use log::{info, trace};
@@ -23,24 +24,27 @@ impl Impl {
         self.sink.set_secret(secret).await
     }
 
-    pub fn set_gist_id(&self, id: &str) {
-        self.sink.set_sink_id(id);
+    pub fn set_gist_id(&self, id: &str) -> anyhow::Result<()> {
+        self.sink.set_sink_id(id)?;
+        Ok(())
     }
 
     pub fn autosync(&self) -> bool {
         self.sink.autosync()
     }
 
-    pub fn set_autosync(&self, autosync: bool) {
-        self.sink.set_autosync(autosync)
+    pub fn set_autosync(&self, autosync: bool) -> anyhow::Result<()> {
+        self.sink.set_autosync(autosync)?;
+        Ok(())
     }
 
     pub fn autosync_timer(&self) -> u32 {
         self.sink.autosync_timer()
     }
 
-    pub fn set_autosync_timer(&self, timer: u32) {
-        self.sink.set_autosync_timer(timer);
+    pub fn set_autosync_timer(&self, timer: u32) -> anyhow::Result<()> {
+        self.sink.set_autosync_timer(timer)?;
+        Ok(())
     }
 
     pub async fn post_gist(&self) -> Result<(), Error> {
@@ -96,9 +100,8 @@ impl Impl {
         let autostart_desktop_file = Path::new(config::AUTOSTART_DESKTOP_FILE_PATH);
         let desktop_file_name = autostart_desktop_file
             .file_name()
-            .unwrap()
-            .to_str()
-            .unwrap();
+            .and_then(|i| i.to_str())
+            .context("Couldn't get proper filename")?;
 
         let mut autostart_user_folder = glib::user_config_dir();
         autostart_user_folder.push("autostart");

--- a/flatsync-daemon/src/main.rs
+++ b/flatsync-daemon/src/main.rs
@@ -89,7 +89,7 @@ async fn poll_remote(
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> anyhow::Result<()> {
     pretty_env_logger::init();
 
     let (sender_flatpak_installation_changed, mut reciever) =

--- a/flatsync-daemon/src/settings.rs
+++ b/flatsync-daemon/src/settings.rs
@@ -20,7 +20,9 @@ impl Settings {
             SETTINGS_INIT.call_once(|| {
                 SETTINGS = Some(Self(gio::Settings::new("app.drey.FlatSync.Devel")));
             });
-            SETTINGS.clone().unwrap()
+            SETTINGS
+                .clone()
+                .expect("SETTINGS is initialised before clone()")
         }
     }
 }

--- a/libflatsync-common/Cargo.toml
+++ b/libflatsync-common/Cargo.toml
@@ -24,3 +24,4 @@ serde_json = "1"
 thiserror = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 zbus = { version = "3.11.0", default-features = false, features = ["tokio"] }
+anyhow = "1"

--- a/libflatsync-common/src/error.rs
+++ b/libflatsync-common/src/error.rs
@@ -12,4 +12,12 @@ pub enum Error {
     Io(#[from] std::io::Error),
     #[error("Error while dealing with reqwest and OAuth2: {0}")]
     OAuth2ReqwestFailure(String),
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+
+impl Error {
+    pub fn other(err: impl Into<anyhow::Error>) -> Self {
+        Self::Other(err.into())
+    }
 }

--- a/libflatsync-common/src/models/flatpak_installation.rs
+++ b/libflatsync-common/src/models/flatpak_installation.rs
@@ -31,7 +31,7 @@ impl<O: glib::IsA<libflatpak::Installation>> From<O> for FlatpakInstallation {
         let value = value.upcast();
 
         Self {
-            // NOTE: Tried TryFrom, but conflict impl with core::
+            // nozwock: Tried TryFrom, but conflict impl with core::
             // Applies to other such impls in the models aswell
             id: value.id().unwrap().into(),
             path: value.path().and_then(|i| i.path()).unwrap_or_default(),

--- a/libflatsync-common/src/providers/github.rs
+++ b/libflatsync-common/src/providers/github.rs
@@ -108,8 +108,6 @@ impl OauthClientDeviceFlow for GitHubProvider {
 // }
 
 impl GitHubProvider {
-    // NOTE: I see no other relevant error variant, so anyhow it is.
-    // Not sure whether to change fn name to try_new
     pub fn new() -> anyhow::Result<Self> {
         Ok(Self {
             client: get_github_basic_client()?,

--- a/libflatsync-common/src/providers/github.rs
+++ b/libflatsync-common/src/providers/github.rs
@@ -24,7 +24,7 @@ async fn custom_async_http_client(request: HttpRequest) -> Result<HttpResponse, 
     match orig_res {
         Err(e) => Err(Error::OAuth2ReqwestFailure(e.to_string())),
         Ok(mut res) => {
-            let msg = std::str::from_utf8(&res.body).unwrap();
+            let msg = std::str::from_utf8(&res.body).map_err(Error::other)?;
 
             // The oauth2 library expects a 400 error code, but GitHub returns a 200
             // See https://github.com/ramosbugs/oauth2-rs/issues/218#issuecomment-1575245490
@@ -41,14 +41,14 @@ async fn custom_async_http_client(request: HttpRequest) -> Result<HttpResponse, 
     }
 }
 
-pub fn get_github_basic_client() -> BasicClient {
-    BasicClient::new(
+pub fn get_github_basic_client() -> anyhow::Result<BasicClient> {
+    Ok(BasicClient::new(
         ClientId::new(GH_CLIENT_ID.into()),
         None,
-        AuthUrl::new(GH_AUTH_URL.into()).unwrap(),
-        Some(TokenUrl::new(GH_TOKEN_URL.into()).unwrap()),
+        AuthUrl::new(GH_AUTH_URL.into())?,
+        Some(TokenUrl::new(GH_TOKEN_URL.into())?),
     )
-    .set_device_authorization_url(DeviceAuthorizationUrl::new(GH_DEVICE_AUTH_URL.into()).unwrap())
+    .set_device_authorization_url(DeviceAuthorizationUrl::new(GH_DEVICE_AUTH_URL.into())?))
 }
 
 pub struct GitHubProvider {
@@ -58,9 +58,12 @@ pub struct GitHubProvider {
 #[async_trait]
 impl OauthClientDeviceFlow for GitHubProvider {
     async fn device_code(&self) -> Result<StandardDeviceAuthorizationResponse, Error> {
-        let req = self.client.exchange_device_code().unwrap();
+        let req = self.client.exchange_device_code().map_err(Error::other)?;
 
-        Ok(req.request_async(async_http_client).await.unwrap())
+        Ok(req
+            .request_async(async_http_client)
+            .await
+            .map_err(Error::other)?)
     }
 
     async fn register_device(
@@ -98,16 +101,18 @@ impl OauthClientDeviceFlow for GitHubProvider {
     }
 }
 
-impl Default for GitHubProvider {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+// impl Default for GitHubProvider {
+//     fn default() -> Self {
+//         Self::new()
+//     }
+// }
 
 impl GitHubProvider {
-    pub fn new() -> Self {
-        Self {
-            client: get_github_basic_client(),
-        }
+    // NOTE: I see no other relevant error variant, so anyhow it is.
+    // Not sure whether to change fn name to try_new
+    pub fn new() -> anyhow::Result<Self> {
+        Ok(Self {
+            client: get_github_basic_client()?,
+        })
     }
 }


### PR DESCRIPTION
https://gitlab.gnome.org/Cogitri/flatsync/-/issues/37

- [X] Remove unwraps where possible using an opaque error variant.
- [ ] Utilize `anyhow` for errors (variants) solely intended for presenting messages to the user (via logging or notifications).
    - The only instance where this distinction mattered (excluding `DBusError`):
https://github.com/nozwock/flatsync/blob/8d88a8f264f7499d81352cf075c66572b1690039/flatsync-daemon/src/main.rs#L79-L83
Will have to discuss to what extent the anyhow migration needs to be done.

